### PR TITLE
fix: csv1行目の読み取り&複数タグへの対応

### DIFF
--- a/rust/src/bin/prepare.rs
+++ b/rust/src/bin/prepare.rs
@@ -4,14 +4,13 @@ use rust::model::{Geotag, TagGeotag, TagJSON};
 
 fn main() -> Result<(), Box<dyn Error>> {
     eprintln!("loading ../csv/tag.csv ...");
-    // HashMap<String, String>をHashMap<String, Vector<String>>へ変更
-    let mut tag_name_by_id: HashMap<String, Vec<String>> = HashMap::new();
+    let mut tag_names_by_id = HashMap::new();
     {
         let file = File::open("../csv/tag.csv")?;
         let mut tag_csv = ReaderBuilder::new().has_headers(false).from_reader(file);
         for record in tag_csv.records() {
             let record = record?;
-            tag_name_by_id
+            tag_names_by_id
                 .entry(record.get(0).unwrap().to_string())
                 .or_insert_with(Vec::new)
                 .push(record.get(1).unwrap().to_string());
@@ -26,7 +25,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let mut geotag_csv = ReaderBuilder::new().has_headers(false).from_reader(file);
         for record in geotag_csv.records() {
             let record = record?;
-            let tag_names = match tag_name_by_id.get(record.get(0).unwrap()) {
+            let tag_names = match tag_names_by_id.get(record.get(0).unwrap()) {
                 Some(x) => x,
                 None => continue,
             };


### PR DESCRIPTION
`tag_name_by_id`が`HashMap<String, String>`だったので`HashMap<String, Vector<String>>`に変更して複数タグに対応できるようにしました。
`CSVReader::from_path("../csv/tag.csv")?;`だと1行目が読み取れていなかったので`ReaderBuilder::new().has_headers(false)`で読み取れるようにしました。